### PR TITLE
MMDP-292 Add logout and missing login tests

### DIFF
--- a/client/__tests__/containers/Login/login.test.js
+++ b/client/__tests__/containers/Login/login.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Login } from '../../../containers/Login/index';
+
+describe.only('Login Container', () => {
+  const props = {
+    loginUser: jest.fn(),
+    history: { push: jest.fn() },
+    LoginStatus: {
+      payload: {
+        status: 'success',
+      },
+    },
+  };
+  const wrapper = shallow(<Login {...props} />);
+  it('renders the container without crashing', () => {
+    const instance = wrapper.instance();
+    const e = {
+      preventDefault: () => {},
+      target: {
+        name: 'form data',
+      },
+    };
+    instance.onFormSubmit(e);
+    instance.onChange(e);
+    instance.setState({
+      username: 'admin@gmail.com',
+      password: 'password',
+    });
+    instance.onFormSubmit(e);
+    // console.log(instance);
+  });
+});

--- a/client/__tests__/containers/Login/logout.test.js
+++ b/client/__tests__/containers/Login/logout.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { LogOut } from '../../../containers/Login/logout';
+
+describe('Logout Container', () => {
+  const props = {
+    history: { push: jest.fn() },
+    logOutUser: () => {},
+    loginStatus: {},
+  };
+  const wrapper = shallow(<LogOut {...props} />);
+  it('renders the container without crashing', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/client/constants/auth.js
+++ b/client/constants/auth.js
@@ -1,6 +1,3 @@
 export const LOGIN = 'LOGIN';
+export const LOGOUT = 'LOGOUT';
 export const LOGIN_SUCCESS_OR_FAILURE = 'LOGIN_SUCCESS_OR_FAILURE';
-export const baseAPI =
-  process.env.NODE_ENV === 'development'
-    ? process.env.DEV_SERVER_API_URL
-    : process.env.SERVER_APP_API_URL;

--- a/client/containers/Login/index.js
+++ b/client/containers/Login/index.js
@@ -38,18 +38,29 @@ export class Login extends Component {
   };
 
   render() {
+    const { history, LoginStatus } = this.props;
+    const { payload } = LoginStatus;
+    if (payload && payload.status === 'success') {
+      history.push('/');
+    }
     return (
-      <LoginViewForm onSubmit={this.onFormSubmit} onChange={this.onChange} />
+      <LoginViewForm
+        onSubmit={this.onFormSubmit}
+        onChange={this.onChange}
+        {...this.props}
+      />
     );
   }
 }
 
 Login.propTypes = {
   loginUser: PropTypes.func.isRequired,
+  history: PropTypes.shape({}).isRequired,
+  LoginStatus: PropTypes.shape({}).isRequired,
 };
 
 const mapStateToProps = (state) => ({
-  Login: state.response,
+  LoginStatus: state.loginReducer,
 });
 
 const mapDispatchToProps = {

--- a/client/containers/Login/index.scss
+++ b/client/containers/Login/index.scss
@@ -1,5 +1,0 @@
-div.markdown__area {
-  width: 700px;
-  height: 500px;
-  margin: auto;
-}

--- a/client/containers/Login/logout.js
+++ b/client/containers/Login/logout.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { logOutUser } from '../../store/actions/auth/login';
+
+export class LogOut extends Component {
+  componentWillMount = () => {
+    // eslint-disable-next-line no-shadow
+    const { history, logOutUser } = this.props;
+    logOutUser();
+    localStorage.removeItem('userToken');
+    history.push('/login');
+  };
+
+  render() {
+    return <></>;
+  }
+}
+
+const mapStateToProps = (state) => ({
+  loginStatus: state.loginReducer,
+});
+
+const mapDispatchToProps = {
+  logOutUser,
+};
+
+LogOut.propTypes = {
+  logOutUser: PropTypes.func.isRequired,
+  history: PropTypes.shape({}).isRequired,
+  loginStatus: PropTypes.shape({}).isRequired,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(LogOut);

--- a/client/containers/Sidebar/sidebarItems.js
+++ b/client/containers/Sidebar/sidebarItems.js
@@ -84,6 +84,11 @@ export const sidebarItems = [
     menuItems: [],
     path: '/group/list',
   },
+  {
+    title: 'Log out',
+    menuItems: [],
+    path: '/logout',
+  },
 ];
 
 export default sidebarItems;

--- a/client/routes/index.js
+++ b/client/routes/index.js
@@ -4,6 +4,7 @@ import Group from '../views/Group';
 import GroupForm from '../views/Group/GroupForm';
 import GroupUpdateForm from '../views/Group/GroupUpdateView';
 import Login from '../containers/Login';
+import Logout from '../containers/Login/logout';
 import AddReport from '../views/Resources/Report/AddReport';
 import EditReport from '../views/Resources/Report/EditReport';
 import ListReport from '../views/Resources/Report/ListReport';
@@ -57,6 +58,12 @@ const routes = [
     path: '/login',
     name: 'Login',
     component: Login,
+    exact: false,
+  },
+  {
+    path: '/logout',
+    name: 'Logout',
+    component: Logout,
     exact: false,
   },
   {

--- a/client/store/actions/auth/login.js
+++ b/client/store/actions/auth/login.js
@@ -1,4 +1,8 @@
-import { LOGIN, LOGIN_SUCCESS_OR_FAILURE } from '../../../constants/auth';
+import {
+  LOGIN,
+  LOGIN_SUCCESS_OR_FAILURE,
+  LOGOUT,
+} from '../../../constants/auth';
 
 export const loginUser = (data) => ({
   type: LOGIN,
@@ -8,4 +12,11 @@ export const loginUser = (data) => ({
 export const loginSuccessOrFail = (data) => ({
   type: LOGIN_SUCCESS_OR_FAILURE,
   payload: data,
+});
+
+export const logOutUser = () => ({
+  type: LOGOUT,
+  payload: {
+    status: 'logout',
+  },
 });

--- a/client/store/reducers/auth/login.js
+++ b/client/store/reducers/auth/login.js
@@ -1,4 +1,8 @@
-import { LOGIN, LOGIN_SUCCESS_OR_FAILURE } from '../../../constants/auth';
+import {
+  LOGIN,
+  LOGIN_SUCCESS_OR_FAILURE,
+  LOGOUT,
+} from '../../../constants/auth';
 
 /**
  * @param {Object} state - Default application state
@@ -10,6 +14,11 @@ const initialState = {};
 const loginReducer = (state = initialState, action = {}) => {
   switch (action.type) {
     case LOGIN:
+      return {
+        ...state,
+        payload: action.payload,
+      };
+    case LOGOUT:
       return {
         ...state,
         payload: action.payload,

--- a/client/store/sagas/login/loginsaga.js
+++ b/client/store/sagas/login/loginsaga.js
@@ -1,38 +1,22 @@
 import { put, call, takeLatest } from 'redux-saga/effects';
 import toastr from 'toastr';
-import axios from 'axios';
-import API from '../../../utils/keys';
 import { LOGIN } from '../../../constants/auth';
 import { loginSuccessOrFail } from '../../actions/auth/login';
+import loginApiRequest from '../../../utils/login';
 
 toastr.options = {
   positionClass: 'toast-top-center',
   preventDuplicates: true,
 };
-const apiRequest = (url, data) =>
-  axios
-    .post(url, data)
-    .then((response) => response.data)
-    .catch((error) => {
-      if (error.response) {
-        const response = error.response.data;
-        return response;
-      }
-    });
 
 export function* loginuser(action) {
   try {
-    const LOGIN_URL = `${API}/api/v1/auth/login`;
-    const USERDETAILS = action.payload;
-    const response = yield call(apiRequest, LOGIN_URL, USERDETAILS);
+    const response = yield call(loginApiRequest, action.payload);
     yield put(loginSuccessOrFail(response));
     if (response.status === 'success') {
       const userToken = response.data.user.token;
       toastr.success(response.message);
       localStorage.setItem('userToken', userToken);
-      setTimeout(() => {
-        window.location.replace('/');
-      }, 1000);
     } else {
       toastr.warning(response.message);
     }

--- a/client/tests/containers/Login/LoginActions.test.js
+++ b/client/tests/containers/Login/LoginActions.test.js
@@ -1,7 +1,12 @@
-import { LOGIN, LOGIN_SUCCESS_OR_FAILURE } from '../../../constants/auth';
+import {
+  LOGIN,
+  LOGOUT,
+  LOGIN_SUCCESS_OR_FAILURE,
+} from '../../../constants/auth';
 import {
   loginUser,
   loginSuccessOrFail,
+  logOutUser,
 } from '../../../store/actions/auth/login';
 
 describe('Login user action', () => {
@@ -28,5 +33,18 @@ describe('Login success of failure user action', () => {
       payload: userResponse,
     };
     expect(loginSuccessOrFail(userResponse)).toEqual(expectedAction);
+  });
+});
+
+describe('Log out user action', () => {
+  it('should create an action to update the state when the reponse is returned', () => {
+    const userResponse = {
+      status: 'logout',
+    };
+    const expectedAction = {
+      type: LOGOUT,
+      payload: userResponse,
+    };
+    expect(logOutUser(userResponse)).toEqual(expectedAction);
   });
 });

--- a/client/tests/containers/Login/LoginReducer.test.js
+++ b/client/tests/containers/Login/LoginReducer.test.js
@@ -1,5 +1,9 @@
 import loginReducer from '../../../store/reducers/auth/login';
-import { LOGIN, LOGIN_SUCCESS_OR_FAILURE } from '../../../constants/auth';
+import {
+  LOGIN,
+  LOGOUT,
+  LOGIN_SUCCESS_OR_FAILURE,
+} from '../../../constants/auth';
 
 describe('Login reducer', () => {
   it('should return the initial state', () => {
@@ -33,6 +37,21 @@ describe('Login reducer', () => {
     expect(loginReducer({}, action)).toEqual({
       payload: {
         message: 'user login successful',
+      },
+    });
+  });
+
+  it('should return logout', () => {
+    const action = {
+      type: LOGOUT,
+      payload: {
+        status: 'logged out',
+      },
+    };
+
+    expect(loginReducer({}, action)).toEqual({
+      payload: {
+        status: 'logged out',
       },
     });
   });

--- a/client/utils/login.js
+++ b/client/utils/login.js
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import baseAPI from './keys';
+
+const url = `${baseAPI}/api/v1/auth/login`;
+
+const apiRequest = (data) =>
+  axios
+    .post(url, data)
+    .then((response) => response.data)
+    .catch((error) => {
+      if (error.response) {
+        const response = error.response.data;
+        return response;
+      }
+    });
+
+export default apiRequest;


### PR DESCRIPTION
**What does this PR do?**

Adds the missing logout component and refactors the login component to match the current team standards.

**Description of Task to be completed?**

- [x] Add the logout component.
- [x] Add the missing login tests.
- [x] Refactor the login code to match the new changes.


**How should this be manually tested?**
- Clone this branch `ch-improve-login-logout-MMDP-292`
- Run `yarn dev` to start both backend and frontend
- Navigate to ` localhost:1234/login` in your browser to test the frontend implementation
- The token will be stored in the local storage.
- In the browser go the ` localhost:1234/logout` route to log out a user.



**Any background context you want to provide?**

None

**What are the relevant Jira issues?**

[MMDP-292](https://viisaus.atlassian.net/browse/MMDP-292)
**Screenshots**
<img width="731" alt="screenshot 2019-02-13 at 09 44 32" src="https://user-images.githubusercontent.com/12638091/52692153-25e53180-2f74-11e9-9b2a-4aa24c7205ea.png">

