### PR TITLE
MMDP-230 Enable searching and pagination of groups

### DIFF
--- a/client/__tests__/components/Group/group.index.test.js
+++ b/client/__tests__/components/Group/group.index.test.js
@@ -15,6 +15,13 @@ const props = {
         permissions: [{ cms: 'cmss' }],
       },
     ],
+    pagination: {
+      total: 1,
+      currentPage: 1,
+      totalPages: 1,
+      previous: false,
+      next: false,
+    },
   },
   redirectTo: testFunc,
   handleCheckBoxChange: testFunc,

--- a/client/__tests__/containers/Group/Group.index.test.js
+++ b/client/__tests__/containers/Group/Group.index.test.js
@@ -16,6 +16,13 @@ const groups = {
       permissions: [{ cms: 'cmss' }],
     },
   ],
+  pagination: {
+    total: 1,
+    currentPage: 1,
+    totalPages: 1,
+    previous: false,
+    next: false,
+  },
   isFetching: false,
   success: false,
   errors: 'adf',

--- a/client/__tests__/store/saga/group/group.saga.test.js
+++ b/client/__tests__/store/saga/group/group.saga.test.js
@@ -16,12 +16,13 @@ import {
 
 const id = 1;
 const payload = { id };
+const filters = { page: 1, search: '' };
 
 describe('Group saga', async () => {
   describe('fetchGroupsAsync', async () => {
-    const it = sagaHelper(fetchGroupsAsync());
+    const it = sagaHelper(fetchGroupsAsync({ payload: filters }));
     it('should have called api list group', (result) => {
-      expect(result).toEqual(call(api.group.list));
+      expect(result).toEqual(call(api.group.list, filters));
     });
     it('and then trigger an fetchGroups', (result) => {
       expect(result).toEqual(put(fetchGroups({})));
@@ -71,7 +72,7 @@ describe('Group saga', async () => {
       expect(result).toEqual(
         put({
           type: FETCHING_GROUPS,
-          payload: {},
+          payload: filters,
         }),
       );
     });

--- a/client/assets/styles/main.scss
+++ b/client/assets/styles/main.scss
@@ -13,3 +13,4 @@
 @import "components/reports";
 
 @import "pages/documents";
+@import "pages/groups";

--- a/client/assets/styles/pages/_groups.scss
+++ b/client/assets/styles/pages/_groups.scss
@@ -1,0 +1,5 @@
+.app-pagination.groups-pagination {
+  padding-top: 2em;
+  margin-bottom: 3em;
+  padding-right: 1em;
+}

--- a/client/components/Group/ActionButtons.js
+++ b/client/components/Group/ActionButtons.js
@@ -25,7 +25,7 @@ const ActionButtons = ({ bulkDeleteGroups }) => (
             <ActionModal
               triggerText="Delete"
               header="Delete Selected Group"
-              content="Are you sure you want to selected group?"
+              content="Are you sure you want to delete selected group(s)?"
               confirmDeleteGroup={bulkDeleteGroups}
             />
           </Button>

--- a/client/components/Group/GroupForm.js
+++ b/client/components/Group/GroupForm.js
@@ -16,7 +16,7 @@ const GroupForm = ({
   success,
   groupId,
 }) => (
-  <div className="main-content">
+  <div>
     {serverError && (
       <Message warning>
         <Message.Header>{serverError}</Message.Header>

--- a/client/components/Group/GroupItem.js
+++ b/client/components/Group/GroupItem.js
@@ -42,7 +42,7 @@ const GroupItem = ({
             <ActionModal
               triggerText="Delete Group"
               header={`Delete ${group.name} Group`}
-              content="Are you sure you want to this group?"
+              content="Are you sure you want to delete this group?"
               confirmDeleteGroup={confirmDeleteGroup}
               group={group}
             />

--- a/client/components/Group/index.js
+++ b/client/components/Group/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Grid, Input, Button } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import ActionButtons from './ActionButtons';
 import GroupList from './GroupList';
+import Search from '../common/Search';
+import Pagination from '../common/Pagination';
 
 const Group = ({
   groups,
@@ -11,20 +12,12 @@ const Group = ({
   bulkDeleteGroups,
   handeMainCheckBoxChange,
   confirmDeleteGroup,
+  handleSearchChange,
+  handleSearch,
+  handleChangePage,
 }) => (
-  <div className="main-content">
-    <Grid columns={2}>
-      <Grid.Row>
-        <Grid.Column width={12}>
-          <Input fluid icon="search" placeholder="Search groups" />
-        </Grid.Column>
-        <Grid.Column width={4}>
-          <Button fluid className="cool-blue">
-            Search
-          </Button>
-        </Grid.Column>
-      </Grid.Row>
-    </Grid>
+  <div>
+    <Search onChange={handleSearchChange} onSearch={handleSearch} />
     <ActionButtons bulkDeleteGroups={bulkDeleteGroups} />
     <GroupList
       groups={groups}
@@ -32,6 +25,11 @@ const Group = ({
       handleCheckBoxChange={handleCheckBoxChange}
       handeMainCheckBoxChange={handeMainCheckBoxChange}
       confirmDeleteGroup={confirmDeleteGroup}
+    />
+    <Pagination
+      handlePageChange={handleChangePage}
+      data={groups.pagination}
+      className="right floated groups-pagination"
     />
   </div>
 );
@@ -43,6 +41,9 @@ Group.propTypes = {
   handleCheckBoxChange: PropTypes.func.isRequired,
   bulkDeleteGroups: PropTypes.func.isRequired,
   confirmDeleteGroup: PropTypes.func.isRequired,
+  handleSearchChange: PropTypes.func.isRequired,
+  handleSearch: PropTypes.func.isRequired,
+  handleChangePage: PropTypes.func.isRequired,
 };
 
 export default Group;

--- a/client/components/Sidebar/MainContent/index.js
+++ b/client/components/Sidebar/MainContent/index.js
@@ -14,7 +14,7 @@ const MainContent = ({ children, title }) => (
         </Container>
       </div>
     </div>
-    <div className="ui container main main-content">{children}</div>
+    <div className="ui container">{children}</div>
   </div>
 );
 

--- a/client/containers/Group/index.js
+++ b/client/containers/Group/index.js
@@ -31,13 +31,36 @@ export class GroupContainer extends Component {
 
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      search: '',
+    };
   }
 
   componentDidMount() {
-    const { getGroups } = this.props;
-    getGroups({});
+    this.fetchGroups();
   }
+
+  fetchGroups = (page = 1, searchStr = null) => {
+    const { getGroups } = this.props;
+    const { search } = this.state;
+
+    const query = searchStr !== null ? searchStr : search;
+
+    getGroups({ page, search: query });
+  };
+
+  handleSearchChange = (search) => {
+    if (!search) {
+      this.setState({ search });
+      this.fetchGroups(1, search);
+    }
+  };
+
+  handleSearch = (search) => {
+    this.setState({ search });
+
+    this.fetchGroups(1, search);
+  };
 
   redirectTo = (_id) => {
     const { history } = this.props;
@@ -88,6 +111,9 @@ export class GroupContainer extends Component {
         confirmDeleteGroup={this.confirmDeleteGroup}
         bulkDeleteGroups={this.bulkDeleteGroups}
         redirectTo={this.redirectTo}
+        handleSearchChange={this.handleSearchChange}
+        handleSearch={this.handleSearch}
+        handleChangePage={this.fetchGroups}
       />
     );
   }

--- a/client/store/reducers/events/events.js
+++ b/client/store/reducers/events/events.js
@@ -5,7 +5,6 @@ import {
   LIST_EVENTS_FAILURE,
   UPDATE_EVENTS_LIST,
 } from '../../../constants/events';
-import { getPaginationData } from '../../../utils/helpers';
 
 export const initialState = {
   events: [],
@@ -26,8 +25,8 @@ const listEvents = (state = initialState, action = {}) => {
       return {
         ...state,
         fetching: false,
-        events: action.events.data.results,
-        pagination: getPaginationData(action.events.data),
+        events: action.events.data,
+        pagination: action.events.pagination,
       };
     case UPDATE_EVENTS_LIST: {
       const newEvents = state.events.filter(

--- a/client/store/reducers/group/index.js
+++ b/client/store/reducers/group/index.js
@@ -15,6 +15,7 @@ import {
 
 export const initialState = {
   groups: [],
+  pagination: {},
   isFetching: false,
   success: false,
   errors: '',

--- a/client/store/sagas/group/index.js
+++ b/client/store/sagas/group/index.js
@@ -11,8 +11,8 @@ import {
   SET_GROUP,
 } from '../../../constants';
 
-export function* fetchGroupsAsync() {
-  const groups = yield call(api.group.list);
+export function* fetchGroupsAsync({ payload }) {
+  const groups = yield call(api.group.list, payload);
   const data = groups !== undefined ? groups.data : {};
   yield put(fetchGroups(data));
 }
@@ -61,7 +61,10 @@ export function* deleteGroupsAsync({ payload }) {
     yield call(api.group.delete, _id);
     yield put({
       type: FETCHING_GROUPS,
-      payload: {},
+      payload: {
+        page: 1,
+        search: '',
+      },
     });
   } catch (err) {
     yield put({

--- a/client/tests/components/Group/group.index.test.js
+++ b/client/tests/components/Group/group.index.test.js
@@ -15,6 +15,13 @@ const props = {
         permissions: [{ cms: 'cmss' }],
       },
     ],
+    pagination: {
+      total: 1,
+      currentPage: 1,
+      totalPages: 1,
+      previous: false,
+      next: false,
+    },
   },
   redirectTo: testFunc,
   handleCheckBoxChange: testFunc,

--- a/client/tests/containers/Group/Group.index.test.js
+++ b/client/tests/containers/Group/Group.index.test.js
@@ -15,6 +15,13 @@ const groups = {
       permissions: [{ cms: 'cmss' }],
     },
   ],
+  pagination: {
+    total: 1,
+    currentPage: 1,
+    totalPages: 1,
+    previous: false,
+    next: false,
+  },
   isFetching: false,
   success: false,
   errors: 'adf',

--- a/client/utils/api.js
+++ b/client/utils/api.js
@@ -1,4 +1,5 @@
 import { server } from './keys';
+import { formatObjectToParams } from './helpers';
 
 const apiVersion = 'api/v1/';
 const documentsApiPrefix = `${apiVersion}resources/repository/document`;
@@ -6,7 +7,16 @@ const documentsApiPrefix = `${apiVersion}resources/repository/document`;
 export const api = {
   group: {
     create: (data) => server.post('api/groups/', data),
-    list: () => server.get('api/groups/'),
+    list: (payload) => {
+      if (payload) {
+        const { page, search } = payload;
+        return server.get(
+          `api/groups?${formatObjectToParams({ page, name: search })}`,
+        );
+      } else {
+        return server.get('api/groups');
+      }
+    },
     edit: (id, data) => server.put(`api/groups/${id}/`, data),
     delete: (id) => server.delete(`api/groups/${id}/`),
     retrieve: (id) => server.get(`api/groups/${id}/`),

--- a/server/__tests__/tests/api/events.spec.js
+++ b/server/__tests__/tests/api/events.spec.js
@@ -65,7 +65,7 @@ describe('Events API', () => {
       // create 4 events with title 'Foo'
       await createEvent({ title: 'Foo' }, 4);
       const res = await apiListEvents({ title: 'Foo' });
-      expect(res.body.data.results.length).toBe(4);
+      expect(res.body.data.length).toBe(4);
     });
 
     it('should fail for unauthorized users', async () => {

--- a/server/routes/api/events.js
+++ b/server/routes/api/events.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-vars */
 import Events from '../../models/EventsModel';
 import modelHelper from '../../helpers/modelHelper';
-import { filterAndPaginate } from '../../utils/search';
+import { filterAndPaginate, getPaginationData } from '../../utils/search';
 
 export const create = (req, res) => {
   const { mainEvent } = req.body;
@@ -48,11 +48,11 @@ export const get = (req, res) => {
 export const list = (req, res) => {
   filterAndPaginate(Events, req)
     .sort('-dateCreated')
-    .populate('')
-    .exec((err, results) => {
+    .exec((err, data) => {
       res.status(200).send({
         status: 'success',
-        data: results,
+        data: data.results,
+        pagination: getPaginationData(data),
       });
     });
 };

--- a/server/routes/api/group.js
+++ b/server/routes/api/group.js
@@ -1,6 +1,7 @@
 import keystone from 'keystone';
 import Group from '../../models/Group';
 import { getPermissionsMapArray } from '../../utils/permissions';
+import { filterAndPaginate, getPaginationData } from '../../utils/search';
 
 // view helper methods
 /**
@@ -36,15 +37,15 @@ const presentData = (groupData) =>
   });
 
 export const list = (req, res) => {
-  Group.model
-    .find()
+  filterAndPaginate(Group, req)
     .sort('-createdAt')
-    .exec(async (err, groups) =>
+    .exec(async (err, data) => {
       res.json({
         status: 'success',
-        groups: await presentData(groups),
-      }),
-    );
+        groups: await presentData(data.results),
+        pagination: getPaginationData(data),
+      });
+    });
 };
 
 export const get = async (req, res) => {

--- a/server/utils/search.js
+++ b/server/utils/search.js
@@ -71,7 +71,7 @@ export const filterModel = (model, req) =>
  * returns keystone-paginated results. It will find 'John' when the search parameter
  * value is 'hn' To finally execute the query and get the results call the exec()
  * method e.g.
- * filterAndPaginate(User, req).exec(err, results => {...handle error or results});
+ * filterAndPaginate(User, req).exec((err, results) => {...handle error or results});
  *
  * @param model
  * @param req


### PR DESCRIPTION
**What does this PR do?**

Adds the ability to search for groups.

**Description of Task to be completed?**

As an administrator, I want to be able to search for a group by entering my search criteria into a search box.

**How should this be manually tested?**

- Fetch and checkout to `ft-search-groups-MMDP-230`.
- Run `yarn dev-server`.
- Open the frontend application and navigate to Groups. You should see a list of all groups or a message that there are no groups. If no groups exist, add some.
- On the search input above groups items, type in a search string and click the search button. If your search matches the title of any of the groups it will appear on a newly created listing that contains only the relevant results. If no event matches your search you will see no results.
- Erase all the search input and all groups will appear.

**Any background context you want to provide?**

Any pertinent information that should be considered

**What are the relevant Jira issues?**

[MMDP-230](https://viisaus.atlassian.net/browse/MMDP-230)

**Screenshots (if appropriate)**
#### Groups listing
<img width="1083" alt="screenshot 2019-02-15 at 13 03 05" src="https://user-images.githubusercontent.com/8180548/53094805-383f0c80-352c-11e9-893f-873c4ce540e0.png">

#### No match search
<img width="935" alt="screenshot 2019-02-20 at 16 23 46" src="https://user-images.githubusercontent.com/8180548/53094810-3bd29380-352c-11e9-868e-568d826d26bb.png">

#### Matching search
<img width="933" alt="screenshot 2019-02-20 at 16 24 18" src="https://user-images.githubusercontent.com/8180548/53094820-442ace80-352c-11e9-9a18-2815fe82eda7.png">

#### Another page
<img width="937" alt="screenshot 2019-02-20 at 16 24 34" src="https://user-images.githubusercontent.com/8180548/53094827-48ef8280-352c-11e9-83ae-f6a17794aaa2.png">


**Questions:**

N/A