### PR TITLE
MMDP-333 Implement search and pagination for reports

### DIFF
--- a/client/__tests__/components/resources/report/listReports.spec.js
+++ b/client/__tests__/components/resources/report/listReports.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { MemoryRouter } from 'react-router-dom';
 import { ListReport } from '../../../../containers/Resources/Report/ListReport';
 import ListReportGrid from '../../../../components/Resources/Report/ListReport';
 import SimpleLoader from '../../../../components/common/Loader/SimpleLoader';
@@ -16,13 +15,6 @@ const archiveActionState = {
   ...deleteActionState,
   modalAction: 'archive',
 };
-const reports = [
-  {
-    _id: '4456534rfdrdthryhfgdzc',
-    title: 'Awesome report',
-    reportType: 'annual',
-  },
-];
 describe('ListReports', () => {
   let wrapper;
   let props;
@@ -45,18 +37,15 @@ describe('ListReports', () => {
     it('should mount without crashing', () => {
       expect(wrapper.find(SimpleLoader).exists()).toBeTruthy();
       expect(wrapper.find(ListReportGrid).exists()).toBeTruthy();
-      expect(wrapper.find(Pagination).exists()).toBeFalsy();
+      expect(wrapper.find(Pagination).exists()).toBeTruthy();
     });
     it('should get list of reports on component mount', () => {
       expect(wrapper.prop('getReports')).toBeCalledTimes(1);
-      expect(wrapper.prop('getReports')).toBeCalledWith(1);
+      expect(wrapper.prop('getReports')).toBeCalledWith({
+        page: 1,
+        search: '',
+      });
     });
-    // it('should get list of reports for a particular page when a user navigates to that page', () => {
-    //   expect(wrapper.prop('getReports')).toBeCalledWith(1);
-    //   wrapper.setProps({ location: { search: '?page=2' } });
-    //   expect(wrapper.prop('getReports')).toBeCalledTimes(2);
-    //   expect(wrapper.prop('getReports')).toBeCalledWith(2);
-    // });
     it('should display modal when show modal method is called', () => {
       wrapper.find(ListReportGrid).prop('showModal')(event, {
         id: itemToModify,
@@ -87,48 +76,5 @@ describe('ListReports', () => {
       });
       expect(wrapper.state('isOpen')).toBeFalsy();
     });
-  });
-  describe('ListReports with pagination', () => {
-    const currentPage = 1;
-    const totalPages = 3;
-    beforeEach(() => {
-      const propsWithResponse = {
-        ...props,
-        loading: false,
-        location: { search: '?page=1' },
-        response: { meta: { currentPage, totalPages }, reports },
-      };
-      wrapper = mount(
-        <MemoryRouter>
-          <ListReport {...propsWithResponse} />
-        </MemoryRouter>,
-      );
-    });
-    // it('should contain pagination component', () => {
-    //   expect(wrapper.find(Pagination).exists()).toBeTruthy();
-    // });
-    // it('should contain correct link the next page', () => {
-    //   expect(
-    //     wrapper
-    //       .find('a.pagination-area__navigator')
-    //       .at(1)
-    //       .props().href,
-    //   ).toBe(`/?page=${currentPage + 1}`);
-    // });
-    // it('should contain disabled link if the current page is the first page', () => {
-    //   const onClickFn = wrapper
-    //     .find('a.pagination-area__navigator')
-    //     .at(0)
-    //     .props().onClick;
-    //   expect(
-    //     wrapper
-    //       .find('a.pagination-area__navigator')
-    //       .at(0)
-    //       .props().href,
-    //   ).toBe('/');
-    //   expect(onClickFn).toEqual(expect.any(Function));
-    //   onClickFn(event);
-    //   expect(event.preventDefault).toHaveBeenCalled();
-    // });
   });
 });

--- a/client/assets/styles/components/_button.scss
+++ b/client/assets/styles/components/_button.scss
@@ -18,8 +18,10 @@
     border-radius: 3px;
     color: $color-white;
     background-color: $color-ugly-blue;
+    height: 3.45em;
+    width: 16em;
   }
   button.ui.button:hover {
-    background-color: inherit;
+    background-color: #81BDD4;
   }
 }

--- a/client/assets/styles/components/_reports.scss
+++ b/client/assets/styles/components/_reports.scss
@@ -1,0 +1,10 @@
+.reports-pagination {
+  margin-right: 0;
+  position: absolute;
+  right: 9.6%;
+}
+
+.ui.info.message.no-reports {
+  width: 95.5%;
+  margin-left: 1.3em;
+}

--- a/client/assets/styles/main.scss
+++ b/client/assets/styles/main.scss
@@ -10,5 +10,6 @@
 @import "components/pagination";
 @import "components/form";
 @import "components/media";
+@import "components/reports";
 
-@import "pages/documents"
+@import "pages/documents";

--- a/client/components/Resources/Report/ListReport.js
+++ b/client/components/Resources/Report/ListReport.js
@@ -9,6 +9,7 @@ import {
   ARCHIVE_ACTION,
   UNARCHIVE_ACTION,
 } from '../../../utils/helper';
+import Search from '../../common/Search';
 
 const ListReport = ({
   reports,
@@ -17,6 +18,8 @@ const ListReport = ({
   showModal,
   handleModalToggle,
   onConfirm,
+  handleSearch,
+  handleSearchChange,
 }) => {
   let modalInfo;
   if (modalAction === 'delete') {
@@ -36,27 +39,42 @@ const ListReport = ({
   return (
     <>
       <Grid>
-        {/* Todo : search bar to be added here */}
-        <a href="/resources/reports/add" className="btn__add">
-          <Button className="btn__add">New Report</Button>
-        </a>
+        <Grid.Column width={12}>
+          <Search
+            onSearch={handleSearch}
+            onChange={handleSearchChange}
+            className="report-search"
+            placeholder="Search report"
+          />
+        </Grid.Column>
+        <Grid.Column>
+          <a href="/resources/reports/add" className="btn__add">
+            <Button className="btn__add">New Report</Button>
+          </a>
+        </Grid.Column>
       </Grid>
       <Grid relaxed>
-        {reports.map(({ _id: id, title, reportType, archived }) => {
-          return (
-            <Grid.Column key={id} mobile={8} tablet={8} computer={4}>
-              <BlueCard
-                title={title}
-                meta={ucFirstLetter(reportType)}
-                actionLinks={getActionLinks({
-                  id,
-                  archived,
-                  onClick: showModal,
-                })}
-              />
-            </Grid.Column>
-          );
-        })}
+        {reports.length > 0 ? (
+          reports.map(({ _id: id, title, reportType, archived }) => {
+            return (
+              <Grid.Column key={id} mobile={8} tablet={8} computer={4}>
+                <BlueCard
+                  title={title}
+                  meta={ucFirstLetter(reportType)}
+                  actionLinks={getActionLinks({
+                    id,
+                    archived,
+                    onClick: showModal,
+                  })}
+                />
+              </Grid.Column>
+            );
+          })
+        ) : (
+          <div className="ui info message no-reports">
+            <p>No reports found in the records.</p>
+          </div>
+        )}
         <ConfirmModal
           isOpen={isOpen}
           handleModalToggle={handleModalToggle}
@@ -75,6 +93,8 @@ ListReport.propTypes = {
   handleModalToggle: PropTypes.func.isRequired,
   reports: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   onConfirm: PropTypes.func.isRequired,
+  handleSearchChange: PropTypes.func.isRequired,
+  handleSearch: PropTypes.func.isRequired,
 };
 
 export default ListReport;

--- a/client/containers/Resources/Report/ListReport.js
+++ b/client/containers/Resources/Report/ListReport.js
@@ -14,37 +14,21 @@ export class ListReport extends Component {
   state = {
     isOpen: false,
     itemToModify: null,
-    currentPage: null,
+    search: '',
   };
 
   componentDidMount() {
-    const { getReports, location } = this.props;
-    const { search } = location;
-    const query = new URLSearchParams(search);
-    const page = parseInt(query.get('page') || 1, 10);
-    getReports(page);
+    this.fetchReports();
   }
 
-  static getDerivedStateFromProps(nextProps, prevState) {
-    const { location } = nextProps;
-    const { search } = location;
-    const query = new URLSearchParams(search);
-    const page = parseInt(query.get('page') || 1, 10);
-    if (prevState.currentPage !== page) {
-      return {
-        currentPage: page,
-      };
-    }
-    return null;
-  }
+  fetchReports = (page = 1, searchStr = null) => {
+    const { getReports } = this.props;
+    const { search } = this.state;
 
-  componentDidUpdate(prevProps, prevState) {
-    const { currentPage } = this.state;
-    if (prevState.currentPage !== currentPage) {
-      const { getReports } = this.props;
-      getReports(currentPage);
-    }
-  }
+    const query = searchStr !== null ? searchStr : search;
+
+    getReports({ page, search: query });
+  };
 
   handleModalToggle = () => {
     this.setState((state) => ({
@@ -72,12 +56,23 @@ export class ListReport extends Component {
     this.handleModalToggle();
   };
 
+  handleSearch = (search) => {
+    this.setState({ search });
+    this.fetchReports(1, search);
+  };
+
+  handleSearchChange = (search) => {
+    if (!search) {
+      this.setState({ search });
+      this.fetchReports(1, search);
+    }
+  };
+
   render() {
     const { isOpen, modalAction } = this.state;
 
     const { response, loading } = this.props;
-    const { meta = {}, reports = [] } = response;
-    const { currentPage, totalPages } = meta;
+    const { pagination = {}, reports = [] } = response;
     return (
       <>
         <SimpleLoader loading={loading} />
@@ -88,10 +83,14 @@ export class ListReport extends Component {
           modalAction={modalAction}
           handleModalToggle={this.handleModalToggle}
           onConfirm={this.handleConfirmClick}
+          handleSearchChange={this.handleSearchChange}
+          handleSearch={this.handleSearch}
         />
-        {currentPage ? (
-          <Pagination currentPage={currentPage} totalPages={totalPages} />
-        ) : null}
+        <Pagination
+          data={pagination}
+          handlePageChange={this.fetchReports}
+          className="reports-pagination"
+        />
       </>
     );
   }

--- a/client/containers/Sidebar/sidebarItems.js
+++ b/client/containers/Sidebar/sidebarItems.js
@@ -53,7 +53,7 @@ export const sidebarItems = [
     title: 'Resources',
     menuItems: [
       { name: 'Research', path: '/resources/research/add' },
-      { name: 'Report', path: '/resources/reports/add' },
+      { name: 'Report', path: '/resources/reports' },
       { name: 'Media', path: '/resources/report/media' },
       { name: 'Documents', path: '/resources/documents' },
     ],

--- a/client/store/sagas/resources/report.js
+++ b/client/store/sagas/resources/report.js
@@ -62,7 +62,7 @@ export function* fetchReports({ payload }) {
       statusCode: res.status,
       status: res.data.status,
       reports: res.data.data.reports,
-      meta: res.data.data.meta,
+      pagination: res.data.data.pagination,
     };
     yield delay(1000);
     yield put(actions.fetchReportsSuccessful({ response }));

--- a/client/utils/resources/report.js
+++ b/client/utils/resources/report.js
@@ -1,7 +1,7 @@
 import baseAPI, { server } from '../keys';
+import { formatObjectToParams } from '../helpers';
 
 const URL = `${baseAPI}/api/v1`;
-const PAGE_LIMIT = 20;
 export const createReport = (data) =>
   server.post(`${URL}/resources/reports`, data);
 export const updateReport = (id, data) =>
@@ -15,5 +15,7 @@ export const archiveReport = (id, archiveAction) =>
 
 export const fetchReport = (id) => server.get(`${URL}/resources/reports/${id}`);
 
-export const fetchReports = (page = 1) =>
-  server.get(`${URL}/resources/reports/all?page=${page}&limit=${PAGE_LIMIT}`);
+export const fetchReports = ({ page, search }) =>
+  server.get(
+    `${URL}/resources/reports?${formatObjectToParams({ page, title: search })}`,
+  );

--- a/server/__tests__/tests/api/resources/report.spec.js
+++ b/server/__tests__/tests/api/resources/report.spec.js
@@ -109,7 +109,7 @@ describe('Report route', () => {
       expect(res.body).to.have.property('data');
       expect(res.body.data).to.have.property('reports');
       expect(res.body.data.reports).to.be.a('Array');
-      expect(res.body.data.reports).to.have.lengthOf(3);
+      expect(res.body.data.reports).to.have.lengthOf(4);
     });
     it('should get all reports including archived reports', async () => {
       const res = await app.get(getAllRoute);

--- a/server/utils/search.js
+++ b/server/utils/search.js
@@ -83,3 +83,34 @@ export const filterAndPaginate = (model, req) =>
     maxPages: 10,
     filters: getSearchQuery(req),
   });
+
+/**
+ * Get all pagination data from the query result. This can be used to handle the result of
+ * running filterAndPaginate in order to separate results from pagination data e.g.
+ *
+ * filterAndPaginate(User, req).exec((err, data) => {
+ *   return res.json({
+ *     items: data.results,
+ *     pagination: getPaginationData(data),
+ *   })
+ * }
+ *
+ * This will reduce the effort required to introduce pagination where it was not previously
+ * implemented by the frontend.
+ *
+ * @param data
+ */
+export const getPaginationData = (data) => {
+  const {
+    total,
+    currentPage,
+    totalPages,
+    pages,
+    previous,
+    next,
+    first,
+    last,
+  } = data;
+
+  return { total, currentPage, totalPages, pages, previous, next, first, last };
+};


### PR DESCRIPTION
**What does this PR do?**

- Implements the pagination and search functionality for reports

**Description of Task to be completed?**

As an administrator, I want to be able to search for a report by entering my search criteria into a search box.

As an administrator, I want to be able to see paginated reports

**How should this be manually tested?**
- Fetch and checkout to `ft-search-reports-documents-MMPD-333 `.
- Run `yarn dev-server`.
- Open the frontend application and navigate to reports. You should see a list of all reports or a message that there are no reports. If no report exist, add some.
- On the search input above reports items, type in a search string and click the search button. If your search matches the title of any of the report it will appear on a newly created listing that contains only the relevant results. If no report matches your search you will see no results.
- Erase all the search input and all reports will appear.


**What are the relevant Jira issues?**

[MMDP-333](https://viisaus.atlassian.net/browse/MMDP-333)

**Screenshots (if appropriate)**
**Paginated results**
<img width="1438" alt="screenshot 2019-02-21 at 06 50 16" src="https://user-images.githubusercontent.com/29597869/53142482-1635a080-35a5-11e9-8315-a824d3d94575.png">
**Search matching Record**
<img width="1440" alt="screenshot 2019-02-21 at 06 49 37" src="https://user-images.githubusercontent.com/29597869/53142521-48470280-35a5-11e9-8ce9-3d9ea6577264.png">
**No record found**
<img width="1439" alt="screenshot 2019-02-21 at 06 57 30" src="https://user-images.githubusercontent.com/29597869/53142715-023e6e80-35a6-11e9-9764-d899b7417859.png">
**All reports**
<img width="1439" alt="screenshot 2019-02-21 at 06 49 23" src="https://user-images.githubusercontent.com/29597869/53142556-644aa400-35a5-11e9-885d-a4a5a9b99d81.png">

