### PR TITLE
MMDP-402 Allow browser to load auth token

### DIFF
--- a/client/containers/Login/index.js
+++ b/client/containers/Login/index.js
@@ -11,12 +11,12 @@ export class Login extends Component {
   };
 
   componentDidUpdate() {
-    const { history, LoginStatus } = this.props;
+    const { LoginStatus } = this.props;
     const { payload } = LoginStatus;
     if (payload && payload.status === 'success') {
       // allow the browser to set userToken
       setTimeout(() => {
-        history.push('/');
+        window.location.assign('/');
       }, 1000);
     }
   }


### PR DESCRIPTION
**What does this PR do?**

Allow browser to set auth token.

**Description of Task to be completed?**

Using history.push('/') does not allow the browser to reload js. This means that we still have auth token as null. Any requests happening before browser reload fail due to authorization token being null. Use window.location.assign('/') to force reload.

**How should this be manually tested?**

1. Fetch all branches - `git fetch --all`.
2. Checkout to this branch - `git checkout bg-fix-auth-token-MMDP-402`.
3. Run the application - `yarn dev-server`.
4. Log in with an admin account. You should be redirected to the dashboard.
5. Try accessing `Users` or `Groups`. The data should load without any errors.

**Any background context you want to provide?**
None

**What are the relevant Jira issues?**

[MMDP-402](https://viisaus.atlassian.net/browse/MMDP-402)

**Screenshots (if appropriate)**

None

**Questions:**

None