### PR TITLE
MMDP-220 Implement archiving/unarchiving of events on the server side

### DIFF
--- a/server/middleware/repository/archiveHelper.js
+++ b/server/middleware/repository/archiveHelper.js
@@ -1,6 +1,7 @@
 import keystone from 'keystone';
 
 export const Document = () => keystone.list('Document');
+export const Event = () => keystone.list('Event');
 
 export const checkArchiveState = async (id) => {
   const document = Document().model;
@@ -12,8 +13,24 @@ export const checkArchiveState = async (id) => {
   }
 };
 
+export const eventArchiveState = async (id) => {
+  const event = Event().model;
+  try {
+    const evt = await event.findById(id);
+    return evt.archived ? { archived: false } : { archived: true };
+  } catch (e) {
+    throw new Error(e.message);
+  }
+};
+
 export const message = (state) => {
   return state
     ? 'Document archived successfully'
     : 'Document unarchived successfully';
+};
+
+export const eventMessage = (state) => {
+  return state
+    ? 'Event archived successfully'
+    : 'Event unarchived successfully';
 };

--- a/server/routes/api/events.js
+++ b/server/routes/api/events.js
@@ -4,6 +4,12 @@ import keystone from 'keystone';
 import Events from '../../models/Event';
 import modelHelper from '../../helpers/modelHelper';
 import { filterAndPaginate, getPaginationData } from '../../utils/search';
+import {
+  eventArchiveState,
+  eventMessage,
+} from '../../middleware/repository/archiveHelper';
+
+export const Event = keystone.list('Event');
 
 const updateMainEvent = (mainEvent) => {
   if (mainEvent && mainEvent === true) {
@@ -97,6 +103,22 @@ export const update = (req, res) => {
       });
     });
   });
+};
+
+export const archive = async (req, res) => {
+  try {
+    const archived = await eventArchiveState(req.params.id);
+
+    await Event.model.findByIdAndUpdate(req.params.id, archived);
+    return res.status(200).json({
+      message: eventMessage(archived.archived),
+      archived: archived.archived,
+    });
+  } catch (e) {
+    return res.status(404).send({
+      message: 'Event with that id doesnot exist',
+    });
+  }
 };
 
 export const remove = (req, res) => {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -308,7 +308,7 @@ const App = (app) => {
     fileUploadValidator.fileUpload,
     routes.api.file.create,
   );
-
+  // events
   app.post(
     '/api/v1/events',
     [
@@ -331,6 +331,13 @@ const App = (app) => {
     [authOptional, keystone.middleware.api],
     routes.api.events.get,
   );
+
+  app.patch(
+    '/api/v1/events/:id/archive',
+    [authenticate, authorize.cms.events.update, keystone.middleware.api],
+    routes.api.events.archive,
+  );
+
   app.put(
     '/api/v1/events/:id',
     [authenticate, authorize.cms.events.update, keystone.middleware.api],


### PR DESCRIPTION
**What does this PR do?**

- Allows an admin to archive/unarchive Events

**description of Task to be completed?**

- Implement  archiving of an Event
- Implement unarchiving of an Event

**How should this be manually tested?**

- `git fetch`
- `git checkout ft-archiveEvents-MMDP-220`
- Open postman on your machine
- make sure an event already exists
- To archive or unarchive an event `http://0.0.0.0:3000/api/v1/events/{id of event}/archive`


**Any background context you want to provide?**

- None

**What are the relevant Jira issues?**

[MMDP-220](https://viisaus.atlassian.net/browse/MMDP-220)

**Screenshots (if appropriate)**

- Archiving an event
![image](https://user-images.githubusercontent.com/36441430/54700349-e77afd80-4b43-11e9-8a99-a23f652d3d1d.png)

- Unarchiving an event
![image](https://user-images.githubusercontent.com/36441430/54700370-f497ec80-4b43-11e9-9753-8c1bbbd864fc.png)


**Questions:**

None
