### PR TITLE
MMDP-517 Fixing empty views and displaying loaders

### DIFF
--- a/client/assets/styles/events.scss
+++ b/client/assets/styles/events.scss
@@ -16,7 +16,7 @@ $pale-gray: #fafeff;
 }
 
 .event-container {
-  width: 1136px;
+  width: 1000px;
   padding: 40px 64px 80px 0px;
 
   .input-field::placeholder {

--- a/client/components/Resources/Document/MediaList.js
+++ b/client/components/Resources/Document/MediaList.js
@@ -22,9 +22,9 @@ const MediaList = (props) => {
       {!loading && documents.results.length < 1 && (
         <Grid.Row className="ui loading center aligned animated fadeIn">
           <InvalidPage
-            pathLabel={`Add a ${instanceName}`}
+            pathLabel={`Add a ${instanceName} `}
             errorMessage={`No ${instanceName} to display`}
-            errorDescription={`Please add ${instanceName}`}
+            errorDescription={`Please add ${instanceName} `}
             path={addMediaUrl || '/'}
           />
         </Grid.Row>

--- a/client/components/Resources/Report/ListReport.js
+++ b/client/components/Resources/Report/ListReport.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Grid, Button } from 'semantic-ui-react';
 import BlueCard from '../../common/Card/BlueCard';
 import ConfirmModal from '../../common/Modal/ConfirmModal';
+import InvalidPage from '../../common/InvalidPage';
 import {
   ucFirstLetter,
   ARCHIVE_ACTION,
@@ -13,6 +14,8 @@ import Search from '../../common/Search';
 const ListReport = ({
   reports,
   isOpen,
+  instanceName,
+  addReportUrl,
   modalAction,
   showModal,
   handleModalToggle,
@@ -78,9 +81,14 @@ const ListReport = ({
               );
             })
           : !loading && (
-              <div className="ui info message no-reports">
-                <p>No reports found in the records.</p>
-              </div>
+              <Grid.Row className="ui loading center aligned animated fadeIn">
+                <InvalidPage
+                  pathLabel={`Add a ${instanceName}`}
+                  errorMessage={`No ${instanceName} to display`}
+                  errorDescription={`Please add ${instanceName}`}
+                  path={addReportUrl || '/'}
+                />
+              </Grid.Row>
             )}
         <ConfirmModal
           isOpen={isOpen}

--- a/client/components/Resources/Research/ListResearch.js
+++ b/client/components/Resources/Research/ListResearch.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Grid, Button } from 'semantic-ui-react';
 import BlueCard from '../../common/Card/BlueCard';
 import ConfirmModal from '../../common/Modal/ConfirmModal';
+import InvalidPage from '../../common/InvalidPage';
 import {
   ucFirstLetter,
   ARCHIVE_ACTION,
@@ -14,6 +15,8 @@ const ListResearch = ({
   results,
   isOpen,
   modalAction,
+  addResearchUrl,
+  instanceName,
   showModal,
   handleModalToggle,
   onConfirm,
@@ -78,9 +81,14 @@ const ListResearch = ({
               );
             })
           : !loading && (
-              <div className="ui info message no-reports">
-                <p>No research found in the records.</p>
-              </div>
+              <Grid.Row className="ui loading center aligned animated fadeIn">
+                <InvalidPage
+                  pathLabel={`Add a ${instanceName}`}
+                  errorMessage={`No ${instanceName} to display`}
+                  errorDescription={`Please add ${instanceName}`}
+                  path={addResearchUrl || '/'}
+                />
+              </Grid.Row>
             )}
         <ConfirmModal
           isOpen={isOpen}

--- a/client/components/events/EventsList.js
+++ b/client/components/events/EventsList.js
@@ -4,18 +4,20 @@ import PropTypes from 'prop-types';
 import { Button } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 import EventCard from './EventCard';
+import SimpleLoader from '../common/Loader/SimpleLoader';
 import Search from '../common/Search';
 
-const EventsList = ({
-  events,
-  handleDelete,
-  handleSearch,
-  handleSearchChange,
-}) => {
+const EventsList = (props) => {
+  const {
+    events,
+    loading,
+    handleDelete,
+    handleSearch,
+    handleSearchChange,
+  } = props;
   const showEvents = events.map((event_) => (
     <EventCard props={event_} key={event_._id} handleDelete={handleDelete} />
   ));
-
   return (
     <React.Fragment>
       <div className="events-container">
@@ -33,13 +35,12 @@ const EventsList = ({
             </Link>
           </div>
         </div>
-        {events.length ? (
+        {!loading && events.length ? (
           <div className="ui grid list-body">{showEvents}</div>
         ) : (
-          <div className="ui info message no-search-events">
-            <p>There are no events that match your search.</p>
-          </div>
+          ''
         )}
+        {loading && <SimpleLoader loading={loading} />}
       </div>
     </React.Fragment>
   );

--- a/client/containers/Resources/Media/MediaList.js
+++ b/client/containers/Resources/Media/MediaList.js
@@ -47,7 +47,7 @@ export class MediaList extends Component {
 
 const mapStateToProps = (state) => ({
   documents: state.documents.data,
-  loading: state.documents.loading,
+  loading: state.documents.isFetching,
   isDeleting: state.media.isDeleting,
   deleteMediaId: state.media._id,
 });

--- a/client/containers/Resources/Report/ListReport.js
+++ b/client/containers/Resources/Report/ListReport.js
@@ -79,6 +79,8 @@ export class ListReport extends Component {
         <ListReportGrid
           reports={reports}
           isOpen={isOpen}
+          instanceName="Report"
+          addReportUrl="/resources/reports/add"
           showModal={this.showModal}
           modalAction={modalAction}
           handleModalToggle={this.handleModalToggle}

--- a/client/containers/Resources/Research/ListResearch.js
+++ b/client/containers/Resources/Research/ListResearch.js
@@ -82,6 +82,8 @@ export class ListResearch extends Component {
         <SimpleLoader loading={loading} />
         <ListResearchGrid
           results={researchResults}
+          instanceName="Research"
+          addResearchUrl="/resources/research/add"
           isOpen={isOpen}
           showModal={this.showModal}
           modalAction={modalAction}

--- a/client/containers/events/eventsList.js
+++ b/client/containers/events/eventsList.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import EventsList from '../../components/events/EventsList';
 import { listEvents } from '../../store/actions/events/event';
 import EmptyView from '../../components/common/InvalidPage';
-import SidebarMenu from '../Sidebar/index';
 import Pagination from '../../components/common/Pagination';
 import '../../assets/styles/events.scss';
 
@@ -40,18 +39,28 @@ export class ListEvents extends Component {
   };
 
   render() {
-    const { events, pagination } = this.props;
-    const { search } = this.state;
-
-    return events.length > 0 || search ? (
+    const { events, loading, pagination } = this.props;
+    return (
       <React.Fragment>
         <div className="event-container">
           <EventsList
             events={events}
+            loading={loading}
             handleDelete={this.handleDelete}
             handleSearchChange={this.handleSearchChange}
             handleSearch={this.handleSearch}
+            {...this.props}
           />
+          {!loading && events.length < 1 && (
+            <React.Fragment>
+              <EmptyView
+                errorMessage="No Event to display"
+                errorDescription=" There are no events to be displayed here"
+                path="/create-event"
+                pathLabel="Add Event"
+              />
+            </React.Fragment>
+          )}
           <div>
             <Pagination
               className="right floated events-pagination"
@@ -61,16 +70,6 @@ export class ListEvents extends Component {
           </div>
         </div>
       </React.Fragment>
-    ) : (
-      <React.Fragment>
-        <SidebarMenu />
-        <EmptyView
-          errorMessage="No Event to display"
-          errorDescription=" There are no events to be displayed here"
-          path="/create-event"
-          pathLabel="Add Event"
-        />
-      </React.Fragment>
     );
   }
 }
@@ -78,6 +77,7 @@ export class ListEvents extends Component {
 export const mapStateToProps = (state) => ({
   events: state.listEvents.events,
   pagination: state.listEvents.pagination,
+  loading: state.listEvents.fetching,
   open: state.open,
 });
 


### PR DESCRIPTION
**What does this PR do?**

Fixes empty views to display only when no content is available in response in the following pages;
- [x] media page
- [x] events page 
- [x] documents pages. 

**Description of Task to be completed?**

Fixes empty views to display only when no content is available in response. Implementing simple loaders to show in place of the empty view that was showing before the content is loaded in the components.

**How should this be manually tested?**

- Fetch and checkout to bg-fix-display-loader-MMDP-517
- On your browser navigate to the pages, events and under resources media and documents pages.

**Any background context you want to provide?**

None

**What are the relevant Jira issues?**

[MMDP-517](https://viisaus.atlassian.net/browse/MMDP-517)

**Screenshots**

### Loader to display before contents are mounted

<img width="1280" alt="Screenshot 2019-03-21 at 11 27 44" src="https://user-images.githubusercontent.com/23031493/54740482-98c57600-4bcc-11e9-861a-062a42de879a.png">

### Consistent pages to display no records available for research and reports pages under resources

<img width="1280" alt="Screenshot 2019-03-21 at 11 26 09" src="https://user-images.githubusercontent.com/23031493/54740570-d4f8d680-4bcc-11e9-94f2-01a0486cbe56.png">

<img width="1280" alt="Screenshot 2019-03-21 at 11 25 37" src="https://user-images.githubusercontent.com/23031493/54740579-dd511180-4bcc-11e9-9469-a24053e660a8.png">


**Questions:**

None