### PR TITLE
MMDP-423 disable deleting of states assigned to records

### DIFF
--- a/client/containers/DropDowns/State/index.js
+++ b/client/containers/DropDowns/State/index.js
@@ -28,12 +28,16 @@ export class State extends Component {
     const { loading, states } = this.props;
     const { dropdowns, refresh } = this.state;
     const filtered = filterDropdowns(dropdowns, hasId);
+
     if (
       states.length > 0 &&
       !loading &&
       refresh &&
       filtered.length !== states.length
     ) {
+      // eslint-disable-next-line
+      this.setState({ dropdowns: states, refresh: false });
+    } else if (states.length === 0 && !loading && refresh) {
       // eslint-disable-next-line
       this.setState({ dropdowns: states, refresh: false });
     }

--- a/client/store/sagas/dropdowns/state.js
+++ b/client/store/sagas/dropdowns/state.js
@@ -53,6 +53,10 @@ export function* deleteStatesAsync({ payload }) {
     const data = response ? response.data : {};
     yield put(actions.deleteStateSuccess(data));
     yield put(actions.fetchStates({}));
+    const message = response
+      ? response.data.message
+      : 'State deleted successfully';
+    toastr.success(message);
   } catch (error) {
     yield put(actions.deleteStateFailure({}));
     const message = error.response

--- a/server/__tests__/helpers/dropdowns/LGA.js
+++ b/server/__tests__/helpers/dropdowns/LGA.js
@@ -1,0 +1,17 @@
+import keystone from 'keystone';
+import { faker } from '../commons/base';
+
+const LGA = keystone.list('LGA');
+
+export const createLGA = async (stateId, times = 1) => {
+  const data = {
+    lgaName: faker.random.words(3),
+    stateId,
+  };
+  const localGovernments = [];
+  for (let i = 0; i < times; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    localGovernments.push(await LGA.model.create(data));
+  }
+  return times === 1 ? localGovernments[0] : localGovernments;
+};

--- a/server/__tests__/helpers/dropdowns/StakeholderAddress.js
+++ b/server/__tests__/helpers/dropdowns/StakeholderAddress.js
@@ -1,0 +1,17 @@
+import keystone from 'keystone';
+import { faker } from '../commons/base';
+
+export const StakeholderAddress = () => keystone.list('StakeholderAddress');
+
+export const createStakeholderAddress = async (stateId, times = 1) => {
+  const data = {
+    address: faker.random.words(3),
+    stateId,
+  };
+  const address = [];
+  for (let i = 0; i < times; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    address.push(await StakeholderAddress().model.create(data));
+  }
+  return times === 1 ? address[0] : address;
+};

--- a/server/__tests__/tests/api/dropdowns/state.spec.js
+++ b/server/__tests__/tests/api/dropdowns/state.spec.js
@@ -7,6 +7,8 @@ import {
   faker,
 } from '../../../helpers/commons/base';
 import { createState } from '../../../helpers/dropdowns/state';
+import { createLGA } from '../../../helpers/dropdowns/LGA';
+import { createStakeholderAddress } from '../../../helpers/dropdowns/StakeholderAddress';
 
 const State = keystone.list('State');
 
@@ -88,8 +90,36 @@ describe('State route', () => {
     it('should delete a state', async () => {
       const state = await createState();
       const { _id: id } = state;
-      const res = await app.delete(deleteRoute(id));
+      let res = await app.delete(deleteRoute(id));
       expect(res.status).to.equal(200);
+      expect(res.body).to.have.property('message');
+
+      res = await app.delete(deleteRoute(id));
+      expect(res.status).to.equal(404);
+      expect(res.body).to.have.property('message');
+    });
+
+    it('should not delete a state with LGA assigned to it', async () => {
+      const state = await createState();
+      const { _id: id } = state;
+      await createLGA(id);
+      const res = await app.delete(deleteRoute(id));
+      expect(res.status).to.equal(400);
+      expect(res.body.message).to.equal(
+        'You cannot delete this state. It is already assigned to 1  Local governement(s)',
+      );
+      expect(res.body).to.have.property('message');
+    });
+
+    it('should not delete a state with stakeholder address assigned to it', async () => {
+      const state = await createState();
+      const { _id: id } = state;
+      await createStakeholderAddress(id);
+      const res = await app.delete(deleteRoute(id));
+      expect(res.status).to.equal(400);
+      expect(res.body.message).to.equal(
+        'You cannot delete this state. It is already assigned to 1 stakeholder(s) ',
+      );
       expect(res.body).to.have.property('message');
     });
   });


### PR DESCRIPTION
**What does this PR do?**

- An administrator should NOT be able to delete an option that has been assigned to a record on the system.

**description of Task to be completed?**
- Disable deleting of states assigned to stakeholders address
- Disable deleting of states assigned to local government (LGA)

**How should this be manually tested?**

- Fetch and checkout to ft-disable-delete-assigned-record-MMDP-413
- On your browser navigate to /dropdowns/state from the CMS
- Create a state and get its ID
- (Local government & Stakeholder address is not implemented at the moment but you can test by adding a collection with the state Id.
- Then try deleting a state that has been assigned to either LGA or Stakeholder Address

**Any background context you want to provide?**

- None

**What are the relevant Jira issues?**

[MMDP-423](https://viisaus.atlassian.net/browse/MMDP-423)

**Screenshots (if appropriate)**
<img width="1411" alt="Screenshot 2019-03-21 at 19 20 34" src="https://user-images.githubusercontent.com/17355400/54767624-9b48bf80-4c0e-11e9-889a-394fb4516bb3.png">

<img width="1414" alt="Screenshot 2019-03-21 at 19 21 35" src="https://user-images.githubusercontent.com/17355400/54767638-a26fcd80-4c0e-11e9-9e48-654b292ee0fa.png">


**Questions:**

- None
